### PR TITLE
Switch Vision provider to use lowest ambiguity pose estimation

### DIFF
--- a/Glitch/Lib/main/Glitch/Lib/Vision/Vision.java
+++ b/Glitch/Lib/main/Glitch/Lib/Vision/Vision.java
@@ -212,7 +212,7 @@ public class Vision {
             double dist = Math.sqrt(dx*dx + dy*dy + dz*dz);
             if ((ambiguity <= cfg.maxAmbiguity && ambiguity != -1) && dist < cfg.maxDistanceMeters) {
               cb.poseEstimator.addHeadingData(latest.getTimestampSeconds(), referencePose.getRotation());
-              Optional<EstimatedRobotPose> est = cb.poseEstimator.estimatePnpDistanceTrigSolvePose(latest);
+              Optional<EstimatedRobotPose> est = cb.poseEstimator.estimateLowestAmbiguityPose(latest);
               if (est.isPresent()) {
                 out.add(new Measurement(est.get().estimatedPose.toPose2d(), latest.getTimestampSeconds()));
               }


### PR DESCRIPTION
Crucial for vision to work right (otherwise we need to select the detached4 branch of GlitchLib from the 2026 Chassis Bot Code for it to work, which is not fun).