### PR TITLE
Here's how to fix the LED bug:

### DIFF
--- a/Glitch/Lib/test/Glitch/Lib/LEDTests.java
+++ b/Glitch/Lib/test/Glitch/Lib/LEDTests.java
@@ -1,90 +1,90 @@
-//package Glitch.Lib;
-//
-//import Glitch.Lib.LEDs.AbstractLEDS;
-//import Glitch.Lib.LEDs.FakeLEDS;
-//import edu.wpi.first.wpilibj.AddressableLEDBuffer;
-//import edu.wpi.first.wpilibj.LEDPattern;
-//import edu.wpi.first.wpilibj.util.Color;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.TestInstance;
-//
-//import static org.junit.jupiter.api.Assertions.assertEquals;
-//import static org.junit.jupiter.api.Assertions.assertNotEquals;
-//
-//@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-//public class LEDTests {
-//
-//    private FakeLEDS testInstance = new FakeLEDS();
-//
-//    private AddressableLEDBuffer stripBuffer = testInstance.stripBuffer;
-//
-//    private AbstractLEDS.Section shortSide = testInstance.shortSide;
-//    private AbstractLEDS.Section shortReversed = testInstance.shortReversed;
-//    private AbstractLEDS.Section longSide = testInstance.longSide;
-//    private void periodic() {
-//        testInstance.periodic();
-//    }
-//
-//    @BeforeEach
-//    public void setup() {
-//        shortSide.setPattern(LEDPattern.kOff);
-//        shortReversed.setPattern(LEDPattern.kOff);
-//        longSide.setPattern(LEDPattern.kOff);
-//        periodic();
-//    }
-//
-//    @Test
-//    public void testLEDStripHasLength() {
-//        assertNotEquals(null, stripBuffer);
-//        assertNotEquals(0, stripBuffer.getLength());
-//    }
-//
-//    @Test
-//    public void testOffMeansOff() {
-//        for (int i = 0; i < stripBuffer.getLength(); i++) {
-//            assertEquals(0, stripBuffer.getRed(i),
-//                "LED " + " should be off. It's current red value is " + stripBuffer.getRed(i));
-//            assertEquals(0, stripBuffer.getGreen(i),
-//                "LED " + " should be off. It's current green value is " + stripBuffer.getGreen(i));
-//            assertEquals(0, stripBuffer.getBlue(i),
-//                "LED " + " should be off. It's current blue value is " + stripBuffer.getBlue(i));
-//        }
-//    }
-//
-//    @Test
-//    public void testSetPatternAppliesPatternToStrip() {
-//        LEDPattern pattern = LEDPattern.solid(Color.kRed);
-//        shortSide.setPattern(pattern);
-//        shortReversed.setPattern(pattern);
-//        longSide.setPattern(pattern);
-//        periodic();
-//
-//        for (int i = 0; i < stripBuffer.getLength(); i++) {
-//            assertEquals(255, stripBuffer.getRed(i),
-//                "LED " + i + " should be red. It's current red value is " + stripBuffer.getRed(i));
-//            assertEquals(0, stripBuffer.getGreen(i),
-//                "LED " + i + " should be red. It's current green value is " + stripBuffer.getGreen(i));
-//            assertEquals(0, stripBuffer.getBlue(i),
-//                "LED " + i + " should be red. It's current blue value is " + stripBuffer.getBlue(i));
-//        }
-//    }
-//
-//    @Test
-//    public void testLightStripConstructs() {
-//        testInstance.initializeLEDS(0);
-//
-//        if (testInstance.isStripReal()) {
-//            assertEquals(true, testInstance.isStripReal());
-//            testInstance.disableLEDS();
-//        } else {
-//            assertEquals(true, testInstance.isStripReal(), "LED strip should be real, but is not.");
-//        }
-//    }
-//
-//    @Test
-//    public void testLightStripDisables() {
-//        testInstance.disableLEDS();
-//        assertEquals(false, testInstance.isStripReal(), "LED strip should not be real, but is.");
-//    }
-//}
+package Glitch.Lib;
+
+import Glitch.Lib.LEDs.AbstractLEDS;
+import Glitch.Lib.LEDs.FakeLEDS;
+import edu.wpi.first.wpilibj.AddressableLEDBuffer;
+import edu.wpi.first.wpilibj.LEDPattern;
+import edu.wpi.first.wpilibj.util.Color;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class LEDTests {
+
+   private FakeLEDS testInstance = new FakeLEDS();
+
+   private AddressableLEDBuffer stripBuffer = testInstance.stripBuffer;
+
+   private AbstractLEDS.Section shortSide = testInstance.shortSide;
+   private AbstractLEDS.Section shortReversed = testInstance.shortReversed;
+   private AbstractLEDS.Section longSide = testInstance.longSide;
+   private void periodic() {
+       testInstance.periodic();
+   }
+
+   @BeforeEach
+   public void setup() {
+       shortSide.setPattern(LEDPattern.kOff);
+       shortReversed.setPattern(LEDPattern.kOff);
+       longSide.setPattern(LEDPattern.kOff);
+       periodic();
+   }
+
+   @Test
+   public void testLEDStripHasLength() {
+       assertNotEquals(null, stripBuffer);
+       assertNotEquals(0, stripBuffer.getLength());
+   }
+
+   @Test
+   public void testOffMeansOff() {
+       for (int i = 0; i < stripBuffer.getLength(); i++) {
+           assertEquals(0, stripBuffer.getRed(i),
+               "LED " + " should be off. It's current red value is " + stripBuffer.getRed(i));
+           assertEquals(0, stripBuffer.getGreen(i),
+               "LED " + " should be off. It's current green value is " + stripBuffer.getGreen(i));
+           assertEquals(0, stripBuffer.getBlue(i),
+               "LED " + " should be off. It's current blue value is " + stripBuffer.getBlue(i));
+       }
+   }
+
+   @Test
+   public void testSetPatternAppliesPatternToStrip() {
+       LEDPattern pattern = LEDPattern.solid(Color.kRed);
+       shortSide.setPattern(pattern);
+       shortReversed.setPattern(pattern);
+       longSide.setPattern(pattern);
+       periodic();
+
+       for (int i = 0; i < stripBuffer.getLength(); i++) {
+           assertEquals(255, stripBuffer.getRed(i),
+               "LED " + i + " should be red. It's current red value is " + stripBuffer.getRed(i));
+           assertEquals(0, stripBuffer.getGreen(i),
+               "LED " + i + " should be red. It's current green value is " + stripBuffer.getGreen(i));
+           assertEquals(0, stripBuffer.getBlue(i),
+               "LED " + i + " should be red. It's current blue value is " + stripBuffer.getBlue(i));
+       }
+   }
+
+   @Test
+   public void testLightStripConstructs() {
+       testInstance.initializeLEDS(0);
+
+       if (testInstance.isStripReal()) {
+           assertEquals(true, testInstance.isStripReal());
+           testInstance.disableLEDS();
+       } else {
+           assertEquals(true, testInstance.isStripReal(), "LED strip should be real, but is not.");
+       }
+   }
+
+   @Test
+   public void testLightStripDisables() {
+       testInstance.disableLEDS();
+       assertEquals(false, testInstance.isStripReal(), "LED strip should not be real, but is.");
+   }
+}


### PR DESCRIPTION
Go into "build\classes\main\Glitch\Lib" and delete the entire LEDS folder. Don't worry, it'll come back later. Build the code again. The error should have disappeared as the faulty build folder name no longer exists.